### PR TITLE
rpi: limit m_maxCacheSize to fix texture corruption #1874

### DIFF
--- a/GLideN64/src/Textures.h
+++ b/GLideN64/src/Textures.h
@@ -98,6 +98,11 @@ private:
 	u32 m_cachedBytes;
 	GLint m_curUnpackAlignment;
 	bool m_toggleDumpTex;
+#ifdef VC
+	const size_t m_maxCacheSize = 1500;
+#else
+	const size_t m_maxCacheSize = 8000;
+#endif
 };
 
 void getTextureShiftScale(u32 tile, const TextureCache & cache, f32 & shiftScaleS, f32 & shiftScaleT);

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ else ifneq (,$(findstring rpi,$(platform)))
    endif
    WITH_DYNAREC=arm
    ifneq (,$(findstring rpi2,$(platform)))
-      CPUFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+      CPUFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -DVC
       HAVE_NEON = 1
    else ifneq (,$(findstring rpi3,$(platform)))
       CPUFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard


### PR DESCRIPTION
Port author:gizmo98

https://github.com/gonetz/GLideN64/pull/1874