### PR TITLE
FrameBuffer: fix crash

### DIFF
--- a/GLideN64/src/FrameBuffer.cpp
+++ b/GLideN64/src/FrameBuffer.cpp
@@ -300,6 +300,8 @@ void FrameBuffer::resolveMultisampledTexture(bool _bForce)
 #ifdef GL_MULTISAMPLING_SUPPORT
 	if (m_resolved && !_bForce)
 		return;
+	if (!m_pResolveTexture)
+		return;
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, m_FBO);
 	glReadBuffer(GL_COLOR_ATTACHMENT0);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_resolveFBO);


### PR DESCRIPTION
Port author:Rosalie241

https://github.com/gonetz/GLideN64/pull/2389/files